### PR TITLE
[Feat] 지도기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+.metadata
+bin

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
@@ -1,5 +1,10 @@
 package kr.or.ddit.highSchool.service;
 
+import java.util.List;
+
 public interface HighSchoolService {
+
+	//모든 고등학교 리스트
+	public List<HighSchoolVO> getAllHighSchools();
 
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
@@ -1,0 +1,5 @@
+package kr.or.ddit.highSchool.service;
+
+public interface HighSchoolService {
+
+}

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
@@ -7,4 +7,7 @@ public interface HighSchoolService {
 	//모든 고등학교 리스트
 	public List<HighSchoolVO> getAllHighSchools();
 
+	//고등학교 상세
+	public HighSchoolVO getHighSchoolById(Long hsId);
+
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolService.java
@@ -10,4 +10,7 @@ public interface HighSchoolService {
 	//고등학교 상세
 	public HighSchoolVO getHighSchoolById(Long hsId);
 
+	// 특정 이름으로 고등학교를 조회하는 메서드 추가
+    public List<HighSchoolVO> getHighSchoolsByName(String schoolName);
+
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolVO.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolVO.java
@@ -1,0 +1,8 @@
+package kr.or.ddit.highSchool.service;
+
+import lombok.Data;
+
+@Data
+public class HighSchoolVO {
+
+}

--- a/src/main/java/kr/or/ddit/highSchool/service/HighSchoolVO.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/HighSchoolVO.java
@@ -4,5 +4,22 @@ import lombok.Data;
 
 @Data
 public class HighSchoolVO {
-
+	private Long hsId;
+    private String hsCode; // 학교코드
+    private String hsName; // 학교명
+    private String hsRegion; // 시도명
+    private String hsJurisCode; // 관할 교육청 코드
+    private String hsFoundType; // 설립유형
+    private String hsZipcode; // 우편번호
+    private String hsAddr; // 기본주소
+    private String hsAddrDetail; // 상세주소
+    private String hsTel; // 전화번호
+    private String hsHomepage; // 홈페이지 URL
+    private String hsCoeduType;  // 남녀공학 구분
+    private String hsTypeName; // 학교 종류
+    private String hsGeneralType; // 일반계/전문계
+    private String hsFoundDate; // 설립일자
+    private String hsAnnivAt; // 개교기념일
+    private Double hsLat; // 위도
+    private Double hsLot; // 경도
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
@@ -16,5 +16,7 @@ public interface HighSchoolMapper {
 	//특정 고등학교 ID로 상세 정보를 조회
 	public HighSchoolVO selectHighSchoolById(@Param("hsId") Long hsId); // hsId가 Long 타입으로 변경
 
+	// 특정 고등학교 이름을 파라미터로 받아 HighSchoolVO 리스트를 반환
+	public List<HighSchoolVO> selectHighSchoolsByName(@Param("schoolName") String schoolName);
 
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
@@ -1,8 +1,15 @@
 package kr.or.ddit.highSchool.service.impl;
 
+import java.util.List;
+
 import org.apache.ibatis.annotations.Mapper;
+
+import kr.or.ddit.highSchool.service.HighSchoolVO;
 
 @Mapper
 public interface HighSchoolMapper {
+
+	// 모든 고등학교 정보를 조회하는 메서드 (주소 포함)
+	public List<HighSchoolVO> selectAllHighSchools();
 
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
@@ -3,6 +3,7 @@ package kr.or.ddit.highSchool.service.impl;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import kr.or.ddit.highSchool.service.HighSchoolVO;
 
@@ -11,5 +12,9 @@ public interface HighSchoolMapper {
 
 	// 모든 고등학교 정보를 조회하는 메서드 (주소 포함)
 	public List<HighSchoolVO> selectAllHighSchools();
+	
+	//특정 고등학교 ID로 상세 정보를 조회
+	public HighSchoolVO selectHighSchoolById(@Param("hsId") Long hsId); // hsId가 Long 타입으로 변경
+
 
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolMapper.java
@@ -1,0 +1,8 @@
+package kr.or.ddit.highSchool.service.impl;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface HighSchoolMapper {
+
+}

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
@@ -27,4 +27,11 @@ public class HighSchoolServiceImpl implements HighSchoolService {
 		
 		return highSchoolMapper.selectHighSchoolById(hsId);
 	}
+	
+	//특정 이름의 고등학교 조회
+	@Override
+	public List<HighSchoolVO> getHighSchoolsByName(String schoolName) {
+
+		return highSchoolMapper.selectHighSchoolsByName(schoolName);
+	}
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
@@ -1,10 +1,24 @@
 package kr.or.ddit.highSchool.service.impl;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import kr.or.ddit.highSchool.service.HighSchoolService;
+import kr.or.ddit.highSchool.service.HighSchoolVO;
 
 @Service
 public class HighSchoolServiceImpl implements HighSchoolService {
+
+	@Autowired
+	private HighSchoolMapper highSchoolMapper;
+	
+	//모든 고등학교 리스트
+	@Override
+	public List<HighSchoolVO> getAllHighSchools() {
+		
+		return highSchoolMapper.selectAllHighSchools();
+	}
 
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
@@ -21,4 +21,10 @@ public class HighSchoolServiceImpl implements HighSchoolService {
 		return highSchoolMapper.selectAllHighSchools();
 	}
 
+	//고등학교 상세
+	@Override
+	public HighSchoolVO getHighSchoolById(Long hsId) {
+		
+		return highSchoolMapper.selectHighSchoolById(hsId);
+	}
 }

--- a/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
+++ b/src/main/java/kr/or/ddit/highSchool/service/impl/HighSchoolServiceImpl.java
@@ -1,0 +1,10 @@
+package kr.or.ddit.highSchool.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import kr.or.ddit.highSchool.service.HighSchoolService;
+
+@Service
+public class HighSchoolServiceImpl implements HighSchoolService {
+
+}

--- a/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
+++ b/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
@@ -2,11 +2,15 @@ package kr.or.ddit.highSchool.web;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import kr.or.ddit.highSchool.service.HighSchoolService;
 import kr.or.ddit.highSchool.service.HighSchoolVO;
@@ -46,6 +50,17 @@ public class HighSchoolController {
 
         model.addAttribute("highSchool", highSchool); // HighSchoolVO 객체 자체를 JSP로 전달
         return "highSchool/detail";
+    }
+    
+    //특정 고등학교 ID로 상세 정보를 JSON 형태로 반환하는 API 엔드포인트
+    @GetMapping("/api/highschools/{hsId}") // 이 경로로 요청이 오면
+    @ResponseBody // HighSchoolVO 객체를 JSON으로 변환하여 HTTP 응답 본문에 씀
+    public ResponseEntity<HighSchoolVO> getHighSchoolByIdApi(@PathVariable("hsId") Long hsId) {
+        HighSchoolVO highSchool = highSchoolService.getHighSchoolById(hsId);
+        if (highSchool == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 404 Not Found
+        }
+        return new ResponseEntity<>(highSchool, HttpStatus.OK); // 200 OK와 데이터 반환
     }
     
 }

--- a/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
+++ b/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import kr.or.ddit.highSchool.service.HighSchoolService;
 import kr.or.ddit.highSchool.service.HighSchoolVO;
@@ -35,4 +36,16 @@ public class HighSchoolController {
     	
     	return "highSchool/list";
     }
+    
+    //고등학교 상세 
+    @GetMapping("/detail")
+    public String highSchoolDetailPage(@RequestParam("hsId") Long hsId, Model model) {
+        HighSchoolVO highSchool = highSchoolService.getHighSchoolById(hsId); // DB에서 상세 정보를 조회
+
+        
+
+        model.addAttribute("highSchool", highSchool); // HighSchoolVO 객체 자체를 JSP로 전달
+        return "highSchool/detail";
+    }
+    
 }

--- a/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
+++ b/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
@@ -63,4 +63,15 @@ public class HighSchoolController {
         return new ResponseEntity<>(highSchool, HttpStatus.OK); // 200 OK와 데이터 반환
     }
     
+    /**
+     * 특정 고등학교의 위도, 경도 정보를 JSON 형태로 반환하는 API 엔드포인트입니다.
+     */
+    @GetMapping("/api/highschools/search")
+    @ResponseBody
+    public ResponseEntity<List<HighSchoolVO>> searchHighSchoolCoordinatesApi(@RequestParam("name") String schoolName){
+    	
+    	List<HighSchoolVO> schools = highSchoolService.getHighSchoolsByName(schoolName);
+    	
+    	return ResponseEntity.ok(schools);
+    }
 }

--- a/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
+++ b/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
@@ -1,0 +1,10 @@
+package kr.or.ddit.highSchool.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("highSchool")
+public class HighSchoolController {
+
+}

--- a/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
+++ b/src/main/java/kr/or/ddit/highSchool/web/HighSchoolController.java
@@ -1,10 +1,38 @@
 package kr.or.ddit.highSchool.web;
 
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import kr.or.ddit.highSchool.service.HighSchoolService;
+import kr.or.ddit.highSchool.service.HighSchoolVO;
 
 @Controller
 @RequestMapping("highSchool")
 public class HighSchoolController {
+	
+	private final HighSchoolService highSchoolService;
 
+    public HighSchoolController(HighSchoolService highSchoolService) {
+        this.highSchoolService = highSchoolService;
+        
+    }
+    
+ // 1. 모든 고등학교 목록 조회 API (리스트 화면용)
+    
+    @GetMapping("/list")
+    public String highSchoolListPage(Model model){
+    	
+    	List<HighSchoolVO> highSchools = highSchoolService.getAllHighSchools();
+    	
+    	// JSP에서는 ${highSchools}로 이 데이터에 접근
+    	model.addAttribute("highSchools", highSchools);
+    	
+    	System.out.println("고등학교 개수: " + highSchools.size());
+    	
+    	return "highSchool/list";
+    }
 }

--- a/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
@@ -55,5 +55,32 @@
         FROM HIGH_SCHOOL
         WHERE HS_ID = #{hsId}
     </select>
+    
+    <!-- 
+	// 특정 고등학교 이름을 파라미터로 받아 HighSchoolVO 리스트를 반환
+	public List<HighSchoolVO> selectHighSchoolsByName(@Param("schoolName") String schoolName);
+    -->
+    <select id="selectHighSchoolsByName" parameterType="string" resultType="kr.or.ddit.highSchool.service.HighSchoolVO">
+       SELECT HS_ID
+            , HS_CODE
+            , HS_NAME
+            , HS_REGION_CODE AS hsRegion
+            , HS_JURIS_CODE AS hsJurisCode
+            , HS_FOUND_TYPE AS hsFoundType
+            , HS_ZIPCODE AS hsZipcode
+            , HS_ADDR AS hsAddr
+            , HS_ADDR_DETAIL AS hsAddrDetail
+            , HS_TEL AS hsTel
+            , HS_HOMEPAGE AS hsHomepage
+            , HS_COEDU_TYPE AS hsCoeduType
+            , HS_TYPE_NAME AS hsTypeName
+            , HS_GENERAL_TYPE AS hsGeneralType
+            , HS_FOUND_DATE AS hsFoundDate
+            , HS_ANNIV_AT AS hsAnnivAt
+            , HS_LAT AS hsLat
+            , HS_LOT AS hsLot
+       FROM HIGH_SCHOOL
+       WHERE HS_NAME LIKE '%' || #{schoolName} || '%'  -- Oracle/MySQL/PostgreSQL 등에서 사용
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="kr.or.ddit.highSchool.service.impl.HighSchoolMapper">
+
+	
+
+</mapper>

--- a/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
@@ -27,5 +27,33 @@
 		     , HS_LOT
 		FROM HIGH_SCHOOL
 	 </select>
+	 
+	  <!-- 
+    //특정 고등학교 ID로 상세 정보를 조회
+	public HighSchoolVO selectHighSchoolById(@Param("hsId") Long hsId); // hsId가 Long 타입으로 변경
+     -->
+     <select id="selectHighSchoolById" parameterType="long" resultType="kr.or.ddit.highSchool.service.HighSchoolVO">
+        SELECT
+            HS_ID,
+            HS_CODE,
+            HS_NAME,
+            HS_REGION_CODE AS hsRegion,
+            HS_JURIS_CODE AS hsJurisCode,
+            HS_FOUND_TYPE AS hsFoundType,
+            HS_ZIPCODE AS hsZipcode,
+            HS_ADDR AS hsAddr,
+            HS_ADDR_DETAIL AS hsAddrDetail,
+            HS_TEL AS hsTel,
+            HS_HOMEPAGE AS hsHomepage,
+            HS_COEDU_TYPE AS hsCoeduType,
+            HS_TYPE_NAME AS hsTypeName,
+            HS_GENERAL_TYPE AS hsGeneralType,
+            HS_FOUND_DATE AS hsFoundDate,
+            HS_ANNIV_AT AS hsAnnivAt,
+            HS_LAT AS hsLat,
+            HS_LOT AS hsLot
+        FROM HIGH_SCHOOL
+        WHERE HS_ID = #{hsId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
+++ b/src/main/resources/mybatis/mapper/highSchool-Mapper.xml
@@ -2,6 +2,30 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="kr.or.ddit.highSchool.service.impl.HighSchoolMapper">
 
-	
+	<!-- 
+	// 모든 고등학교 정보를 조회하는 메서드 (주소 포함)
+	public List<HighSchoolVO> selectAllHighSchools();
+	 -->
+	 <select id="selectAllHighSchools" resultType="kr.or.ddit.highSchool.service.HighSchoolVO">
+	 	SELECT HS_ID
+		     , HS_CODE
+		     , HS_NAME
+		     , HS_REGION_CODE
+		     , HS_JURIS_CODE
+		     , HS_FOUND_TYPE
+		     , HS_ZIPCODE
+		     , HS_ADDR
+		     , HS_ADDR_DETAIL
+		     , HS_TEL
+		     , HS_HOMEPAGE
+		     , HS_COEDU_TYPE
+		     , HS_TYPE_NAME
+		     , HS_GENERAL_TYPE
+		     , HS_FOUND_DATE
+		     , HS_ANNIV_AT
+		     , HS_LAT
+		     , HS_LOT
+		FROM HIGH_SCHOOL
+	 </select>
 
 </mapper>

--- a/src/main/resources/static/css/highSchool/detail.css
+++ b/src/main/resources/static/css/highSchool/detail.css
@@ -1,0 +1,225 @@
+@charset "UTF-8";
+body {
+	font-family: 'Malgun Gothic', '맑은 고딕', sans-serif;
+	margin: 0;
+	padding: 20px;
+	background-color: #f8f9fa;
+}
+
+h1 {
+	text-align: center;
+	color: #343a40;
+	margin-bottom: 30px;
+	font-size: 2em;
+}
+
+.school-detail-container {
+	max-width: 800px;
+	margin: 20px auto;
+	padding: 30px;
+	background-color: #fff;
+	border-radius: 10px;
+	box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
+}
+
+.school-info p {
+	margin-bottom: 10px;
+	font-size: 1.1em;
+	color: #333;
+}
+
+.school-info p b {
+	color: #007bff;
+}
+
+#schoolAddress {
+	color: #007bff;
+	cursor: pointer;
+	text-decoration: underline;
+}
+
+#schoolAddress:hover {
+	color: #0056b3;
+}
+
+/* --- 모달 관련 스타일 (highSchoolMap.jsp에서 복사해 올 것) --- */
+/* 모달 오버레이 */
+.modal-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(0, 0, 0, 0.6); /* 반투명 배경 */
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1001;
+}
+
+/* 모달 내용 컨테이너 */
+.modal-content {
+	background-color: #fff;
+	padding: 30px;
+	border-radius: 10px;
+	box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+	max-width: 700px; /* 모달 너비 조절 */
+	width: 90%;
+	max-height: 90%; /* 모달 높이 제한 */
+	overflow-y: auto; /* 내용이 많으면 스크롤 */
+	position: relative;
+	display: flex; /* 내부 요소 정렬을 위해 flexbox 사용 */
+	flex-direction: column; /* 세로 방향 정렬 */
+}
+
+.modal-content h2 {
+	text-align: center;
+	color: #343a40;
+	margin-bottom: 20px;
+	font-size: 1.8em;
+}
+
+.modal-map-container {
+	width: 100%;
+	height: 400px; /* 모달 내 지도의 높이 */
+	border-radius: 8px;
+	border: 1px solid #e0e0e0;
+	margin-bottom: 15px; /* 지도 아래 여백 */
+}
+
+.info-window-content {
+	padding: 10px;
+	font-size: 13px;
+	line-height: 1.6;
+	color: #333;
+	max-width: 200px;
+	word-wrap: break-word;
+	white-space: normal;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.info-window-content b {
+	font-size: 14px;
+	color: #0056b3;
+	display: block;
+	margin-bottom: 5px;
+}
+
+.modal-close-button {
+	display: block;
+	width: 100%;
+	padding: 10px 20px;
+	margin-top: 25px;
+	background-color: #6c757d;
+	color: white;
+	border: none;
+	border-radius: 5px;
+	cursor: pointer;
+	font-size: 1.1em;
+	transition: background-color 0.2s;
+}
+
+.modal-close-button:hover {
+	background-color: #5a6268;
+}
+
+/* 다른 학교 검색 섹션 스타일 */
+.search-container-in-modal { /* 클래스 이름 변경하여 충돌 방지 */
+	text-align: center;
+	padding: 15px;
+	background-color: #f1f1f1;
+	border-radius: 8px;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
+	margin-top: 15px;
+}
+
+.search-container-in-modal input[type="text"] {
+	padding: 10px 15px;
+	width: 70%;
+	border: 1px solid #ced4da;
+	border-radius: 5px;
+	font-size: 1em;
+	margin-right: 10px;
+}
+
+.search-container-in-modal button {
+	padding: 10px 20px;
+	background-color: #007bff;
+	color: white;
+	border: none;
+	border-radius: 5px;
+	cursor: pointer;
+	font-size: 1em;
+	transition: background-color 0.2s;
+}
+
+.search-container-in-modal button:hover {
+	background-color: #0056b3;
+}
+
+.school-list-in-modal { /* 클래스 이름 변경하여 충돌 방지 */
+	list-style: none;
+	padding: 0;
+	margin-top: 15px;
+	max-height: 200px; /* 검색 결과 목록 높이 제한 */
+	overflow-y: auto; /* 목록이 길어지면 스크롤 */
+	border: 1px solid #eee;
+	border-radius: 5px;
+}
+
+.school-list-in-modal li {
+	padding: 10px 15px;
+	border-bottom: 1px solid #eee;
+	cursor: pointer;
+	transition: background-color 0.2s;
+	font-size: 0.95em;
+	color: #495057;
+}
+
+.school-list-in-modal li:last-child {
+	border-bottom: none;
+}
+
+.school-list-in-modal li:hover {
+	background-color: #e9ecef;
+	color: #007bff;
+}
+
+.loading-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(255, 255, 255, 0.8);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	z-index: 1000;
+	font-size: 1.5em;
+	color: #007bff;
+}
+
+/* 목록버튼 */
+.go-to-list-button {
+	display: block; /* 블록 요소로 만들어 margin auto로 중앙 정렬 가능하게 함 */
+	width: fit-content; /* 내용의 크기에 맞춰 너비를 설정 (또는 max-content) */
+	margin: 30px auto 0 auto; /* 상단 마진 30px, 좌우 마진 auto로 중앙 정렬, 하단 마진 0 */
+	padding: 12px 30px; /* 상하 패딩 12px, 좌우 패딩을 넉넉히 줘서 이미지와 유사한 가로 길이 확보 */
+	background-color: #6c757d; /* 회색 (화면 정의서 참조) */
+	color: white; /* 흰색 글자 */
+	border: none; /* 테두리 없음 */
+	border-radius: 5px; /* 모서리 둥글게 */
+	cursor: pointer; /* 마우스 오버 시 포인터 변경 */
+	font-size: 1.1em; /* 글자 크기 */
+	transition: background-color 0.2s, box-shadow 0.2s;
+	/* 배경색 및 그림자 변화에 애니메이션 효과 */
+	text-align: center; /* 텍스트 중앙 정렬 */
+	box-sizing: border-box; /* 패딩과 테두리를 너비에 포함 */
+}
+
+.go-to-list-button:hover {
+	background-color: #5a6268; /* 호버 시 더 진한 회색 */
+	box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15); /* 호버 시 그림자 효과 */
+}

--- a/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
@@ -1,0 +1,35 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+	pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>고등학교 상세 정보</title>
+<!-- CSS 임포트 -->
+    <link rel="stylesheet" href="/css/highSchool/detail.css">
+</head>
+<body>
+	<h1>고등학교 상세 정보</h1>
+
+	<div class="school-detail-container">
+		<h2 id="detailSchoolName"></h2>
+		<div class="school-info">
+			<p>
+				<b>주소:</b> <span id="schoolAddress">정보 불러오는 중...</span>
+			</p>
+			<p>
+				<b>전화번호:</b> <span id="schoolTel">정보 불러오는 중...</span>
+			</p>
+		</div>
+		<button id="goToListButton" class="go-to-list-button">고등학교
+			목록으로</button>
+	</div>
+
+	<div id="loadingOverlay" class="loading-overlay" style="display: none;">
+		<p>정보를 불러오는 중입니다</p>
+	</div>
+
+
+	
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
@@ -28,6 +28,24 @@
 	<div id="loadingOverlay" class="loading-overlay" style="display: none;">
 		<p>정보를 불러오는 중입니다</p>
 	</div>
+	
+	<!-- 주소 클릭시 지도모달 -->
+	<div id="schoolMapModal" class="modal-overlay" style="display: none;">
+		<div class="modal-content">
+			<h2>고등학교 위치 확인</h2>
+			<div id="map" class="modal-map-container"></div>
+
+			<div id="schoolSearchInModal" class="search-container-in-modal"
+				style="display: none;">
+				<input type="text" id="schoolNameInputInModal"
+					placeholder="다른 고등학교 이름 검색" />
+				<button id="searchButtonInModal">검색</button>
+				<ul id="schoolListInMapModal" class="school-list-in-modal">
+				</ul>
+			</div>
+			<button id="closeMapModalButton" class="modal-close-button">닫기</button>
+		</div>
+	</div>
 
 	<script type="text/javascript"
 		src="//dapi.kakao.com/v2/maps/sdk.js?appkey=1881066df7ed9e16e4315953d2419995"></script>
@@ -105,7 +123,209 @@
         }
     });
 
+    // === 2. 지도 관련 유틸리티 함수 (재활용) ===
+    function clearMapMarkersAndInfoWindows() {
+        if (currentMarker) {
+            currentMarker.setMap(null);
+            currentMarker = null;
+        }
+        if (currentInfoWindow) {
+            currentInfoWindow.close();
+            currentInfoWindow = null;
+        }
+    }
+
+    // 마커와 인포윈도우를 생성하고 지도에 표시하는 함수
+    function createMarkerAndInfoWindow(school) {
+        // 기존 마커/인포윈도우 제거
+        clearMapMarkersAndInfoWindows(); 
+
+        if (school.hsLat != null && school.hsLot != null && school.hsLat !== 0 && school.hsLot !== 0) {
+            const position = new kakao.maps.LatLng(school.hsLat, school.hsLot);
+
+            const marker = new kakao.maps.Marker({
+                map: map,
+                position: position,
+                title: school.hsName
+            });
+            currentMarker = marker; // 현재 마커 저장
+
+            const infoContent = `
+                <div class="info-window-content">
+                    <b>\${school.hsName}</b><br>
+                    주소 : \${school.hsAddr || '정보없음'}<br>
+                    전화 : \${school.hsTel || '정보없음'}
+                </div>
+            `;
+
+            const infowindow = new kakao.maps.InfoWindow({
+                content: infoContent,
+                removable: true
+            });
+            currentInfoWindow = infowindow; // 현재 인포윈도우 저장
+
+            // 마커 클릭 시 인포윈도우 열기
+            kakao.maps.event.addListener(marker, 'click', () => {
+                if (currentInfoWindow) currentInfoWindow.close(); // 기존 인포윈도우 닫기
+                infowindow.open(map, marker);
+                map.setCenter(position); // 클릭한 마커 위치로 지도 중심 이동
+                map.setLevel(5); // 적절한 확대 레벨로 변경
+            });
+            
+            // 지도 로드 시 바로 인포윈도우 열기
+            infowindow.open(map, marker);
+
+            // 지도 중심 이동 및 확대
+            map.setCenter(position);
+            map.setLevel(3); // 상세 위치이므로 더 확대
+        } else {
+            // 위치 정보가 없을 경우 처리
+            alert("해당 고등학교의 위치 정보가 없습니다. 지도가 초기 위치로 설정됩니다.");
+            map.setCenter(new kakao.maps.LatLng(36.3504, 127.3845)); // 대전 시청 기준
+            map.setLevel(9);
+        }
+    }
     
+ 	// 모달 닫기 버튼 이벤트 리스너
+    closeMapModalButton.addEventListener('click', () => {
+        schoolMapModal.style.display = 'none';
+        clearMapMarkersAndInfoWindows(); // 모달 닫을 때 마커 및 인포윈도우 제거
+       // schoolSearchInModal.style.display = 'none'; // 검색창도 숨기기
+        schoolListInMapModal.innerHTML = ''; // 검색 결과 목록도 초기화
+    });
+
+    // 모달 외부 클릭 시 닫기
+    schoolMapModal.addEventListener('click', (e) => {
+        if (e.target === schoolMapModal) {
+            schoolMapModal.style.display = 'none';
+            clearMapMarkersAndInfoWindows();
+          //  schoolSearchInModal.style.display = 'none';
+            schoolListInMapModal.innerHTML = '';
+        }
+    });
+
+    // === 3. 지도 모달 제어 함수 ===
+    function openSchoolMapModal(schoolToDisplay) {
+        // 모달 표시
+        schoolMapModal.style.display = 'flex';
+
+        // Kakao Map SDK가 로드된 후에 지도 초기화
+        kakao.maps.load(() => {
+            // 지도 객체가 없다면 초기화 (모달이 처음 열릴 때만)
+            if (!map) {
+                const mapContainer = document.getElementById('map');
+                const mapOption = {
+                    center: new kakao.maps.LatLng(36.3504, 127.3845), // 초기 중심, 바로 아래서 변경될 예정
+                    level: 9
+                };
+                map = new kakao.maps.Map(mapContainer, mapOption);
+            } else {
+                // 이미 초기화된 지도의 크기/레이아웃이 변경되었을 수 있으므로 재조정
+                map.relayout(); 
+            }
+
+            // 전달받은 학교 정보로 마커 표시 및 인포윈도우 열기
+            createMarkerAndInfoWindow(schoolToDisplay);
+            
+         	// 모달이 열릴 때 검색창이 보이도록 설정 (HTML에서 이미 설정되어 있지만, 명시적으로 다시 호출)
+            schoolSearchInModal.style.display = 'block'; 
+            if (map) {
+                 map.relayout(); // 검색창이 보이면서 지도 크기가 변경될 수 있으므로 재조정
+                 // 현재 마커가 있다면 다시 중앙으로 이동하여 지도와 검색창 레이아웃 변화에 대응
+                 if (currentMarker) {
+                    map.setCenter(currentMarker.getPosition());
+                 }
+            }
+            
+        });
+    }
+
+    // === 4. 모달 내에서 다른 학교 검색 기능 ===
+    searchButtonInModal.addEventListener('click', searchHighSchoolInModal);
+    schoolNameInputInModal.addEventListener('keypress', (e) => {
+        if (e.key === 'Enter') {
+            searchHighSchoolInModal();
+        }
+    });
+
+    async function searchHighSchoolInModal() {
+        const schoolName = schoolNameInputInModal.value.trim();
+        if (!schoolName) {
+            alert('검색할 고등학교 이름을 입력해주세요.');
+            return;
+        }
+
+        loadingOverlay.style.display = 'flex'; // 로딩 오버레이 표시
+        schoolListInMapModal.innerHTML = ''; // 기존 목록 초기화
+
+        try {
+            // 백엔드 API 호출 (기존 highSchoolMap.jsp에서 사용하던 검색 API와 동일)
+            const response = await fetch(`/highSchool/api/highschools/search?name=\${encodeURIComponent(schoolName)}`);
+            if (!response.ok) {
+                throw new Error(`HTTP Error! Status: \${response.status}`);
+            }
+            const foundSchools = await response.json();
+            console.log("모달 내 검색 결과:", foundSchools);
+
+            if (foundSchools.length === 0) {
+                schoolListInMapModal.innerHTML = '<li style="text-align: center; color: #6c757d;">검색된 고등학교가 없습니다.</li>';
+                // 검색 결과가 없으면 지도를 초기 중심으로
+                map.setCenter(new kakao.maps.LatLng(36.3504, 127.3845)); 
+                map.setLevel(9);
+            } else if (foundSchools.length === 1) {
+                // 검색 결과가 하나면 바로 지도에 표시
+                createMarkerAndInfoWindow(foundSchools[0]);
+                map.setCenter(new kakao.maps.LatLng(foundSchools[0].hsLat, foundSchools[0].hsLot));
+                map.setLevel(3);
+            } else {
+                // 검색 결과가 여러 개일 경우 목록으로 표시
+                foundSchools.forEach(school => {
+                    const listItem = document.createElement('li');
+                    listItem.textContent = `\${school.hsName} (\${school.hsAddr || '주소 정보 없음'})`;
+                    // 데이터를 dataset에 저장하여 클릭 시 활용
+                    listItem.dataset.hsId = school.hsId;
+                    listItem.dataset.hsLat = school.hsLat;
+                    listItem.dataset.hsLot = school.hsLot;
+                    listItem.dataset.hsName = school.hsName;
+                    listItem.dataset.hsAddr = school.hsAddr;
+                    listItem.dataset.hsTel = school.hsTel;
+
+                    listItem.addEventListener('click', () => {
+                        // 클릭된 학교 정보로 지도에 마커 표시
+                        const selectedSchool = {
+                            hsLat: parseFloat(listItem.dataset.hsLat),
+                            hsLot: parseFloat(listItem.dataset.hsLot),
+                            hsName: listItem.dataset.hsName,
+                            hsAddr: listItem.dataset.hsAddr,
+                            hsTel: listItem.dataset.hsTel
+                        };
+                        createMarkerAndInfoWindow(selectedSchool);
+                        map.setCenter(new kakao.maps.LatLng(selectedSchool.hsLat, selectedSchool.hsLot));
+                        map.setLevel(3);
+                        // 목록을 비워 이전 검색 결과 숨기기 (선택 사항)
+                        schoolListInMapModal.innerHTML = ''; 
+                        schoolNameInputInModal.value = ''; // 검색창 초기화
+                    });
+                    schoolListInMapModal.appendChild(listItem);
+                });
+            }
+        } catch (error) {
+            console.error('모달 내 고등학교 검색 중 오류 발생:', error);
+            alert('모달 내 고등학교 검색 중 오류가 발생했습니다. 콘솔을 확인해주세요.');
+            schoolListInMapModal.innerHTML = '<li style="text-align: center; color: red;">검색 오류 발생.</li>';
+        } finally {
+            loadingOverlay.style.display = 'none'; // 로딩 오버레이 숨기기
+        }
+    }
+
+ 	
+    // === 5. 고등학교 목록으로 버튼 이벤트 리스너 추가 ===
+    goToListButton.addEventListener('click', () => {
+        // 원하는 고등학교 목록 페이지의 URL로 변경해주세요.
+        // 예시: window.location.href = '/highschool/list';
+        // 예시: window.location.href = '/test/highschools';
+        window.location.href = '/highSchool/list'; // 기존 지도 검색 페이지로 이동
+    });
 		
 	</script>
 	

--- a/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/highSchool/detail.jsp
@@ -29,7 +29,85 @@
 		<p>정보를 불러오는 중입니다</p>
 	</div>
 
+	<script type="text/javascript"
+		src="//dapi.kakao.com/v2/maps/sdk.js?appkey=1881066df7ed9e16e4315953d2419995"></script>
+	<script>
+	// 전역 변수 선언
+    let map; // 카카오 지도 객체
+    let currentMarker; // 현재 지도에 표시된 단일 마커
+    let currentInfoWindow; // 현재 열린 인포윈도우
 
+    // DOM 요소 참조
+    // 로딩 오버레이 요소
+    const loadingOverlay = document.getElementById('loadingOverlay');
+ 	// 학교 지도 모달 요소
+    const schoolMapModal = document.getElementById('schoolMapModal');
+ 	// 지도 모달 닫기 버튼 요소
+    const closeMapModalButton = document.getElementById('closeMapModalButton');
+    // 학교 주소 표시 요소
+    const schoolAddressElement = document.getElementById('schoolAddress');
+ 	// 상세 정보 페이지 학교 이름 요소
+    const detailSchoolNameElement = document.getElementById('detailSchoolName');
+ 	// 학교 전화번호 표시 요소
+    const schoolTelElement = document.getElementById('schoolTel');
+ 	// 모달 내 학교 검색 섹션 요소
+    const schoolSearchInModal = document.getElementById('schoolSearchInModal');
+ 	// 모달 내 학교 이름 검색 입력 필드 요소
+    const schoolNameInputInModal = document.getElementById('schoolNameInputInModal');
+ 	// 모달 내 검색 버튼 요소
+    const searchButtonInModal = document.getElementById('searchButtonInModal');
+ 	// 모달 내 검색 결과 목록 요소
+    const schoolListInMapModal = document.getElementById('schoolListInMapModal');
+
+    let currentSchoolData = null; // 현재 상세 정보를 보고 있는 학교 데이터
+
+    // === 1. 페이지 로드 시 상세 정보 불러오기 ===
+    document.addEventListener('DOMContentLoaded', async () => {
+        const urlParams = new URLSearchParams(window.location.search);
+        const hsId = urlParams.get('hsId'); // URL에서 고등학교 ID 가져오기
+
+        if (!hsId) {
+            alert('고등학교 정보가 없습니다.');
+            // 목록 페이지로 리다이렉션 또는 에러 메시지 표시
+            return;
+        }
+
+        loadingOverlay.style.display = 'flex'; // 로딩 오버레이 표시
+        try {
+            // 백엔드에서 특정 ID의 고등학교 상세 정보를 불러오는 API 호출
+            // ** 이 부분은 백엔드에 `/highSchool/api/highschools/{hsId}` 형태의 API가 있어야 합니다.
+            // ** 백엔드 매퍼에 selectHighSchoolById(String hsId) 쿼리를 추가해야 함.
+            const response = await fetch(`/highSchool/api/highschools/\${hsId}`); 
+            if (!response.ok) {
+                throw new Error(`HTTP Error! Status: \${response.status}`);
+            }
+            const school = await response.json();
+            console.log("가져온 고등학교 상세 정보:", school);
+
+            if (school) {
+                currentSchoolData = school; // 현재 학교 데이터 저장
+                detailSchoolNameElement.textContent = school.hsName;
+                schoolAddressElement.textContent = school.hsAddr || '정보없음';
+                schoolTelElement.textContent = school.hsTel || '정보없음';
+
+                // 주소 클릭 시 지도 모달 열기 이벤트 리스너 추가
+                schoolAddressElement.addEventListener('click', () => {
+                    openSchoolMapModal(currentSchoolData);
+                });
+            } else {
+                alert('고등학교 정보를 찾을 수 없습니다.');
+            }
+        } catch (error) {
+            console.error('고등학교 상세 정보를 불러오는 중 오류 발생:', error);
+            alert('고등학교 상세 정보를 불러오는데 실패했습니다. 콘솔을 확인해주세요.');
+        } finally {
+            loadingOverlay.style.display = 'none'; // 로딩 오버레이 숨기기
+        }
+    });
+
+    
+		
+	</script>
 	
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/highSchool/list.jsp
+++ b/src/main/webapp/WEB-INF/views/highSchool/list.jsp
@@ -1,0 +1,50 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>고등학교 목록</title>
+<style>
+    /* 링크처럼 보이도록 커서 변경 */
+    .school-name-link {
+        cursor: pointer;
+        color: blue;
+        text-decoration: underline;
+    }
+</style>
+</head>
+<body>
+    <h1>고등학교 목록</h1>
+    <table border="1">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>이름</th>
+                <th>주소</th>
+                <th>전화번호</th>
+            </tr>
+        </thead>
+        <tbody>
+            <c:forEach var="school" items="${highSchools}">
+                <tr>
+                    <td>${school.hsId}</td>
+                    <td>
+                        <%-- 학교명 클릭 시 상세 페이지로 이동하는 링크 추가 --%>
+                        <a href="${pageContext.request.contextPath}/test/highDetail?hsId=${school.hsId}" class="school-name-link">
+                            ${school.hsName}
+                        </a>
+                    </td>
+                    <td>${school.hsAddr}</td>
+                    <td>${school.hsTel}</td>
+                </tr>
+            </c:forEach>
+            <c:if test="${empty highSchools}">
+                <tr>
+                    <td colspan="4">등록된 고등학교 정보가 없습니다.</td>
+                </tr>
+            </c:if>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/src/main/webapp/WEB-INF/views/highSchool/list.jsp
+++ b/src/main/webapp/WEB-INF/views/highSchool/list.jsp
@@ -31,7 +31,7 @@
                     <td>${school.hsId}</td>
                     <td>
                         <%-- 학교명 클릭 시 상세 페이지로 이동하는 링크 추가 --%>
-                        <a href="${pageContext.request.contextPath}/test/highDetail?hsId=${school.hsId}" class="school-name-link">
+                        <a href="${pageContext.request.contextPath}/highSchool/detail?hsId=${school.hsId}" class="school-name-link">
                             ${school.hsName}
                         </a>
                     </td>


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?


## 작업 내용

기반 데이터 조회 기능 추가:

Controller (HighSchoolController):

@GetMapping("/highSchool/list"): 모든 고등학교 목록을 조회하여 highSchool/list.jsp 뷰에 전달합니다.

@GetMapping("/highSchool/highDetail"): 특정 hsId를 파라미터로 받아 해당 고등학교의 상세 정보를 조회하고 highSchool/detail.jsp 뷰에 전달합니다.

Service (HighSchoolService 및 HighSchoolServiceImpl):

getAllHighSchools(): 데이터베이스에서 전체 고등학교 목록을 조회합니다.

getHighSchoolById(Long hsId): 지정된 학교 ID(hsId)에 해당하는 고등학교 정보를 단건 조회합니다.

Mapper (HighSchoolMapper.xml):

selectAllHighSchools 및 selectHighSchoolById 쿼리를 구현하여 각각 전체 목록 조회 및 ID 기반 상세 조회를 지원합니다.

JSP 페이지 (list.jsp, detail.jsp) 구성:

list.jsp:

getAllHighSchools()를 통해 조회된 전체 고등학교 목록을 테이블 형태로 출력합니다.

각 학교명을 클릭하면 해당 학교의 상세 페이지(highSchool/detail.jsp)로 이동하도록 링크를 구성합니다.

detail.jsp:

선택된 학교의 상세 정보를 출력합니다.

주요 기능: 학교 주소를 클릭할 수 있는 링크를 제공하며, 해당 링크 클릭 시 JavaScript를 통해 카카오맵 API를 호출하여 학교 주소의 위도/경도 정보를 기반으로 지도에 위치를 표시하도록 구성합니다.



## 스크린샷

## 주의사항

Closes #17
